### PR TITLE
Fix generation of vignettes

### DIFF
--- a/vignettes/loo2-large-data.Rmd
+++ b/vignettes/loo2-large-data.Rmd
@@ -10,7 +10,7 @@ params:
 ---
 <!--
 %\VignetteEngine{knitr::rmarkdown}
-%\VignetteIndexEntry{Writing Stan programs for use with the loo package}
+%\VignetteIndexEntry{Using Leave-one-out cross-validation for large data}
 -->
 
 # Introduction


### PR DESCRIPTION
This fixes the following error from devtools::check():

   Error: Duplicate vignette titles.
     Ensure that the %\VignetteIndexEntry lines in the vignette sources
     correspond to the vignette titles.

   duplicated vignette title:
     ‘Writing Stan programs for use with the loo package’