### PR TITLE
Don't issue a warning each time a waic object is printed (#117)

### DIFF
--- a/R/print.R
+++ b/R/print.R
@@ -29,7 +29,7 @@ print.loo <- function(x, digits = 1, ...) {
 #' @rdname print.loo
 print.waic <- function(x, digits = 1, ...) {
   print.loo(x, digits = digits, ...)
-  throw_pwaic_warnings(x$pointwise[, "p_waic"], digits = digits)
+  throw_pwaic_warnings(x$pointwise[, "p_waic"], digits = digits, warn = FALSE)
   invisible(x)
 }
 

--- a/R/waic.R
+++ b/R/waic.R
@@ -152,14 +152,15 @@ waic_object <- function(pointwise, dims) {
 
 # waic warnings
 # @param p 'p_waic' estimates
-throw_pwaic_warnings <- function(p, digits = 1) {
+throw_pwaic_warnings <- function(p, digits = 1, warn = TRUE) {
   badp <- p > 0.4
   if (any(badp)) {
     count <- sum(badp)
     prop <- count / length(badp)
-    .warn(paste0(count, " (", .fr(100 * prop, digits),
-                 "%) p_waic estimates greater than 0.4. "),
-          "We recommend trying loo instead.")
+    msg <- paste0("\n", count, " (", .fr(100 * prop, digits),
+                  "%) p_waic estimates greater than 0.4. ",
+                  "We recommend trying loo instead.")
+    if (warn) .warn(msg) else cat(msg, "\n")
   }
   invisible(NULL)
 }

--- a/tests/testthat/test_print_plot.R
+++ b/tests/testthat/test_print_plot.R
@@ -41,11 +41,9 @@ lwdim_msg <- paste0("Computed from ", prod(dim(LLarr)[1:2]) , " by ",
                     dim(LLarr)[3], " log-weights matrix")
 
 test_that("print.waic output is ok",{
-  expect_output(suppressWarnings(print(waic1)), lldim_msg)
-  expect_warning(
-    capture.output(print(waic1)),
-    "p_waic estimates greater than 0.4. We recommend trying loo instead.",
-    fixed = TRUE
+  expect_output(print(waic1), lldim_msg)
+  expect_output(print(waic1),
+    "p_waic estimates greater than 0.4. We recommend trying loo instead."
   )
 })
 


### PR DESCRIPTION
In a similar vein to what's done for `psis` objects, a warning is raised only when calling `waic()`, and not when printing the resulting object.