### PR TITLE
Fix warnings from roxygen2 7.0.0

### DIFF
--- a/R/loo_compare.psis_loo_ss_list.R
+++ b/R/loo_compare.psis_loo_ss_list.R
@@ -172,7 +172,6 @@ loo_compare_checks.psis_loo_ss_list <- function(loos) {
 
 #' @rdname loo_compare
 #' @export
-#' @inheritParams print.compare.loo
 print.compare.loo_ss <- function(x, ..., digits = 1, simplify = TRUE) {
   xcopy <- x
   if (inherits(xcopy, "old_compare.loo")) {


### PR DESCRIPTION
Recompiling the documentation using the latest roxygen version raises these warnings:

```
Warning message:
Topic 'loo_compare': no parameters to inherit with @inheritParams
* Topic 'loo_compare.default': no parameters to inherit with @inheritParams
* Topic 'print.compare.loo': no parameters to inherit with @inheritParams
* Topic 'print.compare.loo_ss': no parameters to inherit with @inheritParams
```

These are caused by a `@inheritParams` tag that is unnecessary because the `print.compare.loo_ss` function is already documented in the same .rd file that it's trying to inherit from.