### PR TITLE
Parallelise moment matching

### DIFF
--- a/R/loo_moment_matching.R
+++ b/R/loo_moment_matching.R
@@ -151,7 +151,7 @@ loo_moment_match.default <- function(x, loo, post_draws, log_lik_i,
   }
 
   if (cores == 1) {
-    mm_list <- lapply(I, function(i) loo_moment_match_i_fun(i))
+    mm_list <- lapply(X = I, FUN = function(i) loo_moment_match_i_fun(i))
   }
   else {
     if (!os_is_windows()) {

--- a/R/loo_moment_matching.R
+++ b/R/loo_moment_matching.R
@@ -162,7 +162,7 @@ loo_moment_match.default <- function(x, loo, post_draws, log_lik_i,
       cl <- parallel::makePSOCKcluster(cores)
       on.exit(parallel::stopCluster(cl))
       mm_list <- parallel::parLapply(cl = cl, X = I,
-                                    FUN = function(i) loo_moment_match_i_fun(i))
+                                    fun = function(i) loo_moment_match_i_fun(i))
     }
   }
 


### PR DESCRIPTION
This PR fixes parallelisation of moment matching. Now if `cores > 1`, moment matching is run in parallel for different problematic observations. Also the code is neater because the for loop is replaced with lapply.