### PR TITLE
Fix missing dots in 'loo_moment_match'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: loo
 Type: Package
 Title: Efficient Leave-One-Out Cross-Validation and WAIC for Bayesian Models
-Version: 2.3.0.9000
+Version: 2.3.0.9001
 Date: 2020-07-06
 Authors@R: c(person("Aki", "Vehtari", email = "Aki.Vehtari@aalto.fi", role = c("aut")),
              person("Jonah", "Gabry", email = "jsg2201@columbia.edu", role = c("cre", "aut")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 (GitHub issue/PR number in parentheses)
 
-Items for next release go here
+* Fix a bug in `loo_moment_match` that prevented `...` arguments to be used
+correctly. (#149)
 
 
 # loo 2.3.0

--- a/R/loo_moment_matching.R
+++ b/R/loo_moment_matching.R
@@ -367,7 +367,7 @@ loo_moment_match_i <- function(i,
     split_obj <- loo_moment_match_split(
       x, upars, cov, total_shift, total_scaling, total_mapping, i,
       log_prob_upars = log_prob_upars, log_lik_i_upars = log_lik_i_upars,
-      cores = 1, r_eff_i = r_eff_i, is_method = is_method
+      cores = 1, r_eff_i = r_eff_i, is_method = is_method, ...
     )
     log_liki <- split_obj$log_liki
     lwi <- split_obj$lwi

--- a/tests/testthat/test_loo_moment_matching.R
+++ b/tests/testthat/test_loo_moment_matching.R
@@ -307,3 +307,48 @@ test_that("loo_moment_match_split works", {
 
 })
 
+test_that("passing arguments works", {
+  log_lik_i_upars_test_additional_argument <- function(x, upars, i, passed_arg = FALSE, ...) {
+    if (!passed_arg) {
+      warning("passed_arg was not passed here")
+    }
+    -0.5*log(2*pi) - upars[,2] - 1.0/(2*exp(upars[,2])^2)*(x$data$y[i] - upars[,1])^2
+
+  }
+  unconstrain_pars_test_additional_argument <- function(x, pars, passed_arg = FALSE, ...) {
+    if (!passed_arg) {
+      warning("passed_arg was not passed here")
+    }
+    upars <- as.matrix(pars)
+    upars[,2] <- log(upars[,2])
+    upars
+  }
+
+  log_prob_upars_test_additional_argument <- function(x, upars, passed_arg = FALSE, ...) {
+    if (!passed_arg) {
+      warning("passed_arg was not passed here")
+    }
+    dinvchisq(exp(upars[,2])^2,x$data$n - 1,x$data$s2, log = TRUE) +
+      dnorm(upars[,1],x$data$ymean,exp(upars[,2])/sqrt(x$data$n), log = TRUE)
+  }
+  post_draws_test_additional_argument <- function(x, passed_arg = FALSE, ...) {
+    if (!passed_arg) {
+      warning("passed_arg was not passed here")
+    }
+    as.matrix(x$draws)
+  }
+  log_lik_i_test_additional_argument <- function(x, i, passed_arg = FALSE, ...) {
+    if (!passed_arg) {
+      warning("passed_arg was not passed here")
+    }
+    -0.5*log(2*pi) - log(x$draws$sigma) - 1.0/(2*x$draws$sigma^2)*(x$data$y[i] - x$draws$mu)^2
+  }
+
+  # loo object
+  loo_manual <- suppressWarnings(loo(loglik))
+  expect_silent(loo_moment_match(x, loo_manual, post_draws_test_additional_argument, log_lik_i_test_additional_argument,
+                                 unconstrain_pars_test_additional_argument, log_prob_upars_test_additional_argument,
+                                 log_lik_i_upars_test_additional_argument, max_iters = 30L,
+                                 k_thres = 0.5, split = TRUE,
+                                 cov = TRUE, cores = 1, passed_arg = TRUE))
+})


### PR DESCRIPTION
This PR fixes a typo in `loo_moment_match` that prevented `...` to be passed to the `loo_moment_match_split` method. This causes trouble as soon as any additional argument is passed to the helper functions of moment matching. I should have seen this earlier (before the loo release) but unfortunately I didn't. 

@jgabry we should make another small CRAN update as soon as possible to make moment matching generally usable with additional arguments.