### PR TITLE
Fixed a numerical issue in split_moment_matching

### DIFF
--- a/R/split_moment_matching.R
+++ b/R/split_moment_matching.R
@@ -82,26 +82,21 @@ loo_moment_match_split <- function(x, upars, cov, total_shift, total_scaling,
   log_liki_half <- log_lik_i_upars(x, upars = upars_trans_half, i = i, ...)
 
   # compute weights
-  stable_S <- log_prob_half_trans > (log_prob_half_trans_inv -
-                                      log(prod(total_scaling)) -
-                                      log(det(total_mapping)))
+  log_prob_half_trans_inv <- (log_prob_half_trans_inv -
+                              log(prod(total_scaling)) -
+                              log(det(total_mapping)))
+  stable_S <- log_prob_half_trans > log_prob_half_trans_inv
 
   lwi_half <- -log_liki_half + log_prob_half_trans
   lwi_half[stable_S] <- lwi_half[stable_S] -
     (log_prob_half_trans[stable_S] +
       log1p(exp(log_prob_half_trans_inv[stable_S] -
-                log(prod(total_scaling)) -
-                log(det(total_mapping)) -
                   log_prob_half_trans[stable_S])))
 
   lwi_half[!stable_S] <- lwi_half[!stable_S] -
-    ((log_prob_half_trans_inv[!stable_S] -
-      log(prod(total_scaling)) -
-      log(det(total_mapping))) +
+    (log_prob_half_trans_inv[!stable_S] +
         log1p(exp(log_prob_half_trans[!stable_S] -
-                   (log_prob_half_trans_inv[!stable_S] -
-                   log(prod(total_scaling)) -
-                   log(det(total_mapping))))))
+                   log_prob_half_trans_inv[!stable_S])))
 
   is_obj_half <- suppressWarnings(importance_sampling.default(lwi_half,
                                                               method = is_method,

--- a/R/split_moment_matching.R
+++ b/R/split_moment_matching.R
@@ -82,10 +82,26 @@ loo_moment_match_split <- function(x, upars, cov, total_shift, total_scaling,
   log_liki_half <- log_lik_i_upars(x, upars = upars_trans_half, i = i, ...)
 
   # compute weights
-  lwi_half <- -log_liki_half + log_prob_half_trans -
-    (log_prob_half_trans +
-       log(1 + exp(log_prob_half_trans_inv - log(prod(total_scaling)) -
-                     log(det(total_mapping)) - log_prob_half_trans)))
+  stable_S <- log_prob_half_trans > (log_prob_half_trans_inv -
+                                      log(prod(total_scaling)) -
+                                      log(det(total_mapping)))
+
+  lwi_half <- -log_liki_half + log_prob_half_trans
+  lwi_half[stable_S] <- lwi_half[stable_S] -
+    (log_prob_half_trans[stable_S] +
+      log1p(exp(log_prob_half_trans_inv[stable_S] -
+                log(prod(total_scaling)) -
+                log(det(total_mapping)) -
+                  log_prob_half_trans[stable_S])))
+
+  lwi_half[!stable_S] <- lwi_half[!stable_S] -
+    ((log_prob_half_trans_inv[!stable_S] -
+      log(prod(total_scaling)) -
+      log(det(total_mapping))) +
+        log1p(exp(log_prob_half_trans[!stable_S] -
+                   (log_prob_half_trans_inv[!stable_S] -
+                   log(prod(total_scaling)) -
+                   log(det(total_mapping))))))
 
   is_obj_half <- suppressWarnings(importance_sampling.default(lwi_half,
                                                               method = is_method,


### PR DESCRIPTION
This PR fixes the issue https://github.com/stan-dev/rstan/issues/852 .

When computing the density of the split proposal, we need to compute a
logarithm of the sum of two densities `log(a + c)`. In some extreme cases, to compute this in a stable way we need a different formula depending on whether `a >> c` or `a << c`.