### PR TITLE
Update normalizing constant of PSIS weights when moment matching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,8 @@
 
 ### Bug fixes 
 
-* Fixed a bug causing the normalizing constant of the PSIS (log) weights not to get updated when performing moment matching with `save_psis = TRUE` (GitHub issue #166).
+* Fixed a bug causing the normalizing constant of the PSIS (log) weights not 
+to get updated when performing moment matching with `save_psis = TRUE` (#166, @fweber144).
 
 # loo 2.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 * Switch unit tests from Travis to GitHub Actions. (#164)
 
+### Bug fixes 
+
+* Fixed a bug causing the normalizing constant of the PSIS (log) weights not to get updated when performing moment matching with `save_psis = TRUE` (GitHub issue #166).
+
 # loo 2.4.1
 
 * Fixed issue reported by CRAN where one of the vignettes errored on an M1 Mac

--- a/R/loo_moment_matching.R
+++ b/R/loo_moment_matching.R
@@ -151,6 +151,7 @@ loo_moment_match.default <- function(x, loo, post_draws, log_lik_i,
     }
   }
   if (!is.null(loo$psis_object)) {
+    attr(loo$psis_object, "norm_const_log") <- matrixStats::colLogSumExps(loo$psis_object$log_weights)
     loo$psis_object$diagnostics <- loo$diagnostics
   }
 


### PR DESCRIPTION
This fixes issue #166.