### PR TITLE
mention how to specify names in loo_compare doc

### DIFF
--- a/R/E_loo.R
+++ b/R/E_loo.R
@@ -51,6 +51,7 @@
 #'
 #' @examples
 #' \donttest{
+#' if (requireNamespace("rstanarm", quietly = TRUE)) {
 #' # Use rstanarm package to quickly fit a model and get both a log-likelihood
 #' # matrix and draws from the posterior predictive distribution
 #' library("rstanarm")
@@ -80,6 +81,7 @@
 #' # To get Pareto k diagnostic with E_loo we also need to provide the negative
 #' # log-likelihood values using the log_ratios argument.
 #' E_loo(yrep, psis_object, type = "mean", log_ratios = log_ratios)
+#' }
 #' }
 #'
 E_loo <- function(x, psis_object, ...) {

--- a/R/loo_compare.R
+++ b/R/loo_compare.R
@@ -6,8 +6,11 @@
 #'   `print(..., simplify=FALSE)` to print a more detailed summary.
 #'
 #' @export
-#' @param x An object of class `"loo"` or a list of such objects.
-#' @param ... Additional objects of class `"loo"`.
+#' @param x An object of class `"loo"` or a list of such objects. If a list is
+#'   used then the list names will be used as the model names in the output. See
+#'   **Examples**.
+#' @param ... Additional objects of class `"loo"`, if not passed in as a single
+#'   list.
 #'
 #' @return A matrix with class `"compare.loo"` that has its own
 #'   print method. See the **Details** section.
@@ -55,8 +58,9 @@
 #' # (will be the same for all models in this artificial example)
 #' print(comp, simplify = FALSE, digits = 3)
 #'
-#' # can use a list of objects
-#' loo_compare(x = list(loo1, loo2, loo3))
+#' # can use a list of objects with custom names
+#' # will use apple, banana, and cherry, as the names in the output
+#' loo_compare(list("apple" = loo1, "banana" = loo2, "cherry" = loo3))
 #'
 #' \dontrun{
 #' # works for waic (and kfold) too

--- a/man/E_loo.Rd
+++ b/man/E_loo.Rd
@@ -83,6 +83,7 @@ development and will be added in a future release.
 }
 \examples{
 \donttest{
+if (requireNamespace("rstanarm", quietly = TRUE)) {
 # Use rstanarm package to quickly fit a model and get both a log-likelihood
 # matrix and draws from the posterior predictive distribution
 library("rstanarm")
@@ -112,6 +113,7 @@ E_loo(yrep, psis_object, type = "quantile", probs = c(0.1, 0.9))
 # To get Pareto k diagnostic with E_loo we also need to provide the negative
 # log-likelihood values using the log_ratios argument.
 E_loo(yrep, psis_object, type = "mean", log_ratios = log_ratios)
+}
 }
 
 }

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -16,9 +16,12 @@ loo_compare(x, ...)
 \method{print}{compare.loo_ss}(x, ..., digits = 1, simplify = TRUE)
 }
 \arguments{
-\item{x}{An object of class \code{"loo"} or a list of such objects.}
+\item{x}{An object of class \code{"loo"} or a list of such objects. If a list is
+used then the list names will be used as the model names in the output. See
+\strong{Examples}.}
 
-\item{...}{Additional objects of class \code{"loo"}.}
+\item{...}{Additional objects of class \code{"loo"}, if not passed in as a single
+list.}
 
 \item{digits}{For the print method only, the number of digits to use when
 printing.}
@@ -78,8 +81,9 @@ print(comp, digits = 2)
 # (will be the same for all models in this artificial example)
 print(comp, simplify = FALSE, digits = 3)
 
-# can use a list of objects
-loo_compare(x = list(loo1, loo2, loo3))
+# can use a list of objects with custom names
+# will use apple, banana, and cherry, as the names in the output
+loo_compare(list("apple" = loo1, "banana" = loo2, "cherry" = loo3))
 
 \dontrun{
 # works for waic (and kfold) too


### PR DESCRIPTION
Closes #172 by mentioning that a named list can be used in order to get custom names in the output. 