### PR TITLE
autocovariance -> posterior::autocovariance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Suggests:
     ggplot2,
     graphics,
     knitr,
+    posterior,
     rmarkdown,
     rstan,
     rstanarm (>= 2.19.0),


### PR DESCRIPTION
closes #157

Replace's loo's internal `autocovariance()` function with `posterior::autocovariance()`