### PR TITLE
fix loo_model_weights naming for list of loo objects

### DIFF
--- a/R/loo_compare.R
+++ b/R/loo_compare.R
@@ -231,8 +231,7 @@ find_model_names <- function(x) {
       out_names[j] <- names4[j]
     }
   }
-
-  return(out_names)
+  out_names
 }
 
 

--- a/man/loo_model_weights.Rd
+++ b/man/loo_model_weights.Rd
@@ -27,15 +27,16 @@ stacking_weights(lpd_point, optim_method = "BFGS", optim_control = list())
 pseudobma_weights(lpd_point, BB = TRUE, BB_n = 1000, alpha = 1)
 }
 \arguments{
-\item{x}{A list of pointwise log-likelihood matrices or \code{"psis_loo"} objects
-(objects returned by \code{\link[=loo]{loo()}}), one for each model. Each
-matrix/object should have dimensions \eqn{S} by \eqn{N}, where \eqn{S} is
-the size of the posterior sample (with all chains merged) and \eqn{N} is
-the number of data points. If \code{x} is a list of log-likelihood matrices
-then \code{\link[=loo]{loo()}} is called internally on each matrix. Currently the
-\code{loo_model_weights()} function is not implemented to be used with
-results from K-fold CV, but you can still obtain weights using K-fold CV
-results by calling the \code{stacking_weights()} function directly.}
+\item{x}{A list of \code{"psis_loo"} objects (objects returned by \code{\link[=loo]{loo()}}) or
+pointwise log-likelihood matrices or , one for each model. If the list
+elements are named the names will be used to label the models in the
+results. Each matrix/object should have dimensions \eqn{S} by \eqn{N},
+where \eqn{S} is the size of the posterior sample (with all chains merged)
+and \eqn{N} is the number of data points. If \code{x} is a list of
+log-likelihood matrices then \code{\link[=loo]{loo()}} is called internally on each matrix.
+Currently the \code{loo_model_weights()} function is not implemented to be used
+with results from K-fold CV, but you can still obtain weights using K-fold
+CV results by calling the \code{stacking_weights()} function directly.}
 
 \item{...}{Unused, except for the generic to pass arguments to individual
 methods.}
@@ -185,6 +186,9 @@ wts2 <- loo_model_weights(
   optim_control = list(reltol=1e-10)
 )
 all.equal(wts1, wts2)
+
+# can provide names to be used in the results
+loo_model_weights(setNames(loo_list, c("A", "B", "C")))
 
 
 # pseudo-BMA+ method:

--- a/tests/testthat/test_model_weighting.R
+++ b/tests/testthat/test_model_weighting.R
@@ -94,4 +94,22 @@ test_that("stacking_weights and pseudobma_weights throw correct errors", {
   expect_error(pseudobma_weights(xx), "two models are required")
 })
 
+test_that("loo_model_weights uses correct names for list of loo objects", {
+  loo1 <- loo_list[[1]]
+  loo2 <- loo_list[[2]]
+  loo3 <- loo_list[[3]]
+
+  expect_named(
+    loo_model_weights(list(loo1, loo2, loo3)),
+    c("model1", "model2", "model3")
+  )
+  expect_named(
+    loo_model_weights(list("a" = loo1, loo2, "c" = loo3)),
+    c("a", "model2", "c")
+  )
+  expect_named(
+    loo_model_weights(list(`a` = loo1, `b` = loo2, `c` = loo3)),
+    c("a", "b", "c")
+  )
+})
 


### PR DESCRIPTION
fixes #165 by getting model names for `loo_model_weights` even if list of loo objects is only partially named 

@avehtari Does this behave as expected now? 