### PR TITLE
Revert "autocovariance -> posterior::autocovariance"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,6 @@ Suggests:
     ggplot2,
     graphics,
     knitr,
-    posterior,
     rmarkdown,
     rstan,
     rstanarm (>= 2.19.0),

--- a/R/effective_sample_sizes.R
+++ b/R/effective_sample_sizes.R
@@ -199,13 +199,17 @@ psis_n_eff.matrix <- function(w, r_eff = NULL, ...) {
 #' @return MCMC effective sample size based on RStan's calculation.
 #'
 ess_rfun <- function(sims) {
-  if (!requireNamespace("posterior", quietly = TRUE)) {
-    stop("Please install the 'posterior' package", call. = FALSE)
-  }
+  # Compute the effective sample size for samples of several chains
+  # for one parameter; see the C++ code of function
+  # effective_sample_size in chains.cpp
+  #
+  # Args:
+  #   sims: a 2-d array _without_ warmup samples (# iter * # chains)
+  #
   if (is.vector(sims)) dim(sims) <- c(length(sims), 1)
   chains <- ncol(sims)
   n_samples <- nrow(sims)
-  acov <- lapply(1:chains, FUN = function(i) posterior::autocovariance(sims[,i]))
+  acov <- lapply(1:chains, FUN = function(i) autocovariance(sims[,i]))
   acov <- do.call(cbind, acov)
   chain_mean <- colMeans(sims)
   mean_var <- mean(acov[1,]) * n_samples / (n_samples - 1)
@@ -270,4 +274,19 @@ fft_next_good_size <- function(N) {
       return(N)
     N = N + 1
   }
+}
+
+autocovariance <- function(y) {
+  # Compute autocovariance estimates for every lag for the specified
+  # input sequence using a fast Fourier transform approach.
+  N <- length(y)
+  M <- fft_next_good_size(N)
+  Mt2 <- 2 * M
+  yc <- y - mean(y)
+  yc <- c(yc, rep.int(0, Mt2-N))
+  transform <- stats::fft(yc)
+  ac <- stats::fft(Conj(transform) * transform, inverse = TRUE)
+  # use "biased" estimate as recommended by Geyer (1992)
+  ac <- Re(ac)[1:N] / (N^2 * 2)
+  ac
 }


### PR DESCRIPTION
Reverts stan-dev/loo#215

Some reverse dependency checks failed due to this change because I added an error if posterior isn't installed. We either need to force the installation of posterior (e.g. put it in Imports, which isn't ideal but OK if we plan on using it more in loo in the future) or we need to notify maintainers of affected packages well in advance of release. I will think about this and open a new PR to deal with it after merging this one. 