### PR TITLE
use posterior::autocovariance if available

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: loo
 Type: Package
 Title: Efficient Leave-One-Out Cross-Validation and WAIC for Bayesian Models
 Version: 2.6.0
-Date: 2023-03-29
+Date: 2023-03-30
 Authors@R: c(person("Aki", "Vehtari", email = "Aki.Vehtari@aalto.fi", role = c("aut")),
              person("Jonah", "Gabry", email = "jsg2201@columbia.edu", role = c("cre", "aut")),
              person("Mans", "Magnusson", role = c("aut")),
@@ -43,6 +43,7 @@ Suggests:
     ggplot2,
     graphics,
     knitr,
+    posterior,
     rmarkdown,
     rstan,
     rstanarm (>= 2.19.0),

--- a/R/effective_sample_sizes.R
+++ b/R/effective_sample_sizes.R
@@ -199,17 +199,14 @@ psis_n_eff.matrix <- function(w, r_eff = NULL, ...) {
 #' @return MCMC effective sample size based on RStan's calculation.
 #'
 ess_rfun <- function(sims) {
-  # Compute the effective sample size for samples of several chains
-  # for one parameter; see the C++ code of function
-  # effective_sample_size in chains.cpp
-  #
-  # Args:
-  #   sims: a 2-d array _without_ warmup samples (# iter * # chains)
-  #
   if (is.vector(sims)) dim(sims) <- c(length(sims), 1)
   chains <- ncol(sims)
   n_samples <- nrow(sims)
-  acov <- lapply(1:chains, FUN = function(i) autocovariance(sims[,i]))
+  if (requireNamespace("posterior", quietly = TRUE)) {
+    acov <- lapply(1:chains, FUN = function(i) posterior::autocovariance(sims[,i]))
+  } else {
+    acov <- lapply(1:chains, FUN = function(i) autocovariance(sims[,i]))
+  }
   acov <- do.call(cbind, acov)
   chain_mean <- colMeans(sims)
   mean_var <- mean(acov[1,]) * n_samples / (n_samples - 1)
@@ -276,6 +273,7 @@ fft_next_good_size <- function(N) {
   }
 }
 
+# autocovariance function to use if posterior::autocovariance is not available
 autocovariance <- function(y) {
   # Compute autocovariance estimates for every lag for the specified
   # input sequence using a fast Fourier transform approach.


### PR DESCRIPTION
advances #157 