### PR TITLE
make Pareto k Inf if it is NA

### DIFF
--- a/R/gpdfit.R
+++ b/R/gpdfit.R
@@ -49,7 +49,7 @@ gpdfit <- function(x, wip = TRUE, min_grid_pts = 30, sort_x = TRUE) {
     k <- adjust_k_wip(k, n = N)
   }
 
-  if (is.nan(k)) {
+  if (is.na(k)) {
     k <- Inf
   }
 


### PR DESCRIPTION
This PR changes the handling of Pareto k values in edge cases. If Pareto k is NaN or NA, it will be changed to Inf, whereas previously it was done only for NaN. Based on the discussion in https://github.com/stan-dev/loo/issues/222.