### PR TITLE
update array syntax in vignettes

### DIFF
--- a/vignettes/loo2-elpd.Rmd
+++ b/vignettes/loo2-elpd.Rmd
@@ -35,12 +35,14 @@ This vignette uses the same example as in the vignettes
 Here is the Stan code for fitting a Poisson regression model:
 
 ```{r stancode}
+# Note: some syntax used in this Stan program requires RStan >= 2.26 (or CmdStanR)
+# To use an older version of RStan change the line declaring `y` to: int y[N];
 stancode <- "
 data {
   int<lower=1> K;
   int<lower=1> N;
   matrix[N,K] x;
-  int y[N];
+  array[N] int y;
   vector[N] offset;
 
   real beta_prior_scale;

--- a/vignettes/loo2-large-data.Rmd
+++ b/vignettes/loo2-large-data.Rmd
@@ -67,12 +67,14 @@ Here is the Stan code for fitting the logistic regression model, which
 we save in a file called `logistic.stan`:
 
 ```
-// save in `logistic.stan`
+// Note: some syntax used in this program requires RStan >= 2.26 (or CmdStanR)
+// To use an older version of RStan change the line declaring `y` to:
+//    int<lower=0,upper=1> y[N];
 data {
   int<lower=0> N;             // number of data points
   int<lower=0> P;             // number of predictors (including intercept)
   matrix[N,P] X;              // predictors (including 1s for intercept)
-  int<lower=0,upper=1> y[N];  // binary outcome
+  array[N] int<lower=0,upper=1> y;  // binary outcome
 }
 parameters {
   vector[P] beta;

--- a/vignettes/loo2-mixis.Rmd
+++ b/vignettes/loo2-mixis.Rmd
@@ -39,11 +39,14 @@ set.seed(24877)
 This is the Stan code for a logistic regression model with regularized horseshoe prior. The code includes an if statement to include a code line needed later for the MixIS approach.
 
 ```{r stancode_horseshoe}
+# Note: some syntax used in this program requires RStan >= 2.26 (or CmdStanR)
+# To use an older version of RStan change the line declaring `y` to:
+#    int<lower=0,upper=1> y[N];
 stancode_horseshoe <- "
 data {
   int <lower=0> n;                
   int <lower=0> p;                
-  int <lower=0, upper=1> y[n];    
+  array[N] int <lower=0, upper=1> y;    
   matrix [n,p] X;                
   real <lower=0> scale_global;
   int <lower=0,upper=1> mixis;                

--- a/vignettes/loo2-moment-matching.Rmd
+++ b/vignettes/loo2-moment-matching.Rmd
@@ -60,12 +60,14 @@ Here is the Stan code for fitting the Poisson regression model, which
 we will use for modeling the number of roaches.
 
 ```{r stancode}
+# Note: some syntax used in this Stan program requires RStan >= 2.26 (or CmdStanR)
+# To use an older version of RStan change the line declaring `y` to: int y[N];
 stancode <- "
 data {
   int<lower=1> K;
   int<lower=1> N;
   matrix[N,K] x;
-  int y[N];
+  array[N] int y;
   vector[N] offset;
 
   real beta_prior_scale;

--- a/vignettes/loo2-with-rstan.Rmd
+++ b/vignettes/loo2-with-rstan.Rmd
@@ -57,11 +57,14 @@ Here is the Stan code for fitting the logistic regression model, which
 we save in a file called `logistic.stan`:
 
 ```
+// Note: some syntax used in this program requires RStan >= 2.26 (or CmdStanR)
+// To use an older version of RStan change the line declaring `y` to:
+//    int<lower=0,upper=1> y[N];
 data {
-  int<lower=0> N;             // number of data points
-  int<lower=0> P;             // number of predictors (including intercept)
-  matrix[N,P] X;              // predictors (including 1s for intercept)
-  int<lower=0,upper=1> y[N];  // binary outcome
+  int<lower=0> N;                   // number of data points
+  int<lower=0> P;                   // number of predictors (including intercept)
+  matrix[N,P] X;                    // predictors (including 1s for intercept)
+  array[N] int<lower=0,upper=1> y;  // binary outcome
 }
 parameters {
   vector[P] beta;


### PR DESCRIPTION
Updates vignettes to use new array syntax but includes comments indicating how to use the old syntax if using an older version of rstan (that way loo doesn't need to require rstan >= 2.26) 