### PR TITLE
Add order statistic warning

### DIFF
--- a/R/loo_compare.R
+++ b/R/loo_compare.R
@@ -44,7 +44,7 @@
 #'
 #'   If more than \eqn{11} models are compared, then the worst model by elpd is
 #'   taken as the baseline model, and the risk of the difference in predictive
-#'   performance being due to random noise is estimated as described by
+#'   performance being due to chance is estimated as described by
 #'   McLatchie and Vehtari (2023). This will flag a warning if it is deemed that
 #'   there is a risk of over-fitting due to the selection process, and users
 #'   are recommended to avoid model selection based on LOO-CV, and
@@ -319,7 +319,7 @@ loo_order_stat_check <- function(loos, ord) {
 
   if (max(elpd_diff) <= order_stat) {
     # flag warning if we suspect no model is theoretically better than the baseline
-    warning("Difference in performance potentially due to random noise.",
+    warning("Difference in performance potentially due to chance.",
             call. = FALSE)
   }
 }

--- a/R/loo_compare.R
+++ b/R/loo_compare.R
@@ -42,16 +42,14 @@
 #'   distribution, a practice derived for Gaussian linear models or
 #'   asymptotically, and which only applies to nested models in any case.
 #'
-#'   If more than \eqn{11} models are compared, then the median model by elpd is
-#'   taken as the baseline model, and we recompute (internally) the model
-#'   differences to this baseline. We then estimate whether the difference in
-#'   predictive performances is potentially due to chance as described by
-#'   McLatchie and Vehtari (2023). This will flag a warning if it is deemed that
-#'   there is a risk of over-fitting due to the selection process, and users
-#'   are recommended to avoid model selection based on LOO-CV, and
-#'   instead to favour of model averaging/stacking or projection predictive
-#'   inference.
-#'
+#'   If more than \eqn{11} models are compared, we internally recompute the model
+#'   differences using the median model by ELPD as the baseline model. We then
+#'   estimate whether the differences in predictive performance are potentially
+#'   due to chance as described by McLatchie and Vehtari (2023). This will flag
+#'   a warning if it is deemed that there is a risk of over-fitting due to the
+#'   selection process. In that case users are recommended to avoid model
+#'   selection based on LOO-CV, and instead to favor model averaging/stacking or
+#'   projection predictive inference.
 #' @seealso
 #' * The [FAQ page](https://mc-stan.org/loo/articles/online-only/faq.html) on
 #'   the __loo__ website for answers to frequently asked questions.

--- a/R/loo_compare.R
+++ b/R/loo_compare.R
@@ -43,11 +43,11 @@
 #'   asymptotically, and which only applies to nested models in any case.
 #'
 #'   If more than \eqn{11} models are compared, then the worst model by elpd is
-#'   taken as the baseline model, and the risk of difference in predictive
+#'   taken as the baseline model, and the risk of the difference in predictive
 #'   performance being due to random noise is estimated as described by
 #'   McLatchie and Vehtari (2023). This will flag a warning if it is deemed that
 #'   there is a risk of over-fitting due to the selection process, and users
-#'   are recommended to either avoid model selection based on LOO-CV, and
+#'   are recommended to avoid model selection based on LOO-CV, and
 #'   instead to favour of model averaging/stacking or projection predictive
 #'   inference.
 #'

--- a/man-roxygen/loo-and-compare-references.R
+++ b/man-roxygen/loo-and-compare-references.R
@@ -1,0 +1,14 @@
+#' @references
+#' Vehtari, A., Gelman, A., and Gabry, J. (2017). Practical Bayesian model
+#' evaluation using leave-one-out cross-validation and WAIC.
+#' *Statistics and Computing*. 27(5), 1413--1432. doi:10.1007/s11222-016-9696-4
+#' ([journal version](https://link.springer.com/article/10.1007/s11222-016-9696-4),
+#'  [preprint arXiv:1507.04544](https://arxiv.org/abs/1507.04544)).
+#'
+#' Vehtari, A., Simpson, D., Gelman, A., Yao, Y., and Gabry, J. (2019).
+#' Pareto smoothed importance sampling.
+#' [preprint arXiv:1507.02646](https://arxiv.org/abs/1507.02646)
+#'
+#' McLatchie, Y., and Vehtari, A. (2023).
+#' Efficient estimation and correction of selection-induced bias with order statistics.
+#' [preprint arXiv:2309.03742](https://arxiv.org/abs/2309.03742)

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -68,11 +68,11 @@ distribution, a practice derived for Gaussian linear models or
 asymptotically, and which only applies to nested models in any case.
 
 If more than \eqn{11} models are compared, then the worst model by elpd is
-taken as the baseline model, and the risk of difference in predictive
+taken as the baseline model, and the risk of the difference in predictive
 performance being due to random noise is estimated as described by
 McLatchie and Vehtari (2023). This will flag a warning if it is deemed that
 there is a risk of over-fitting due to the selection process, and users
-are recommended to either avoid model selection based on LOO-CV, and
+are recommended to avoid model selection based on LOO-CV, and
 instead to favour of model averaging/stacking or projection predictive
 inference.
 }

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -69,7 +69,7 @@ asymptotically, and which only applies to nested models in any case.
 
 If more than \eqn{11} models are compared, then the worst model by elpd is
 taken as the baseline model, and the risk of the difference in predictive
-performance being due to random noise is estimated as described by
+performance being due to chance is estimated as described by
 McLatchie and Vehtari (2023). This will flag a warning if it is deemed that
 there is a risk of over-fitting due to the selection process, and users
 are recommended to avoid model selection based on LOO-CV, and

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -67,9 +67,10 @@ standard approach of comparing differences of deviances to a Chi-squared
 distribution, a practice derived for Gaussian linear models or
 asymptotically, and which only applies to nested models in any case.
 
-If more than \eqn{11} models are compared, then the worst model by elpd is
-taken as the baseline model, and the risk of the difference in predictive
-performance being due to chance is estimated as described by
+If more than \eqn{11} models are compared, then the median model by elpd is
+taken as the baseline model, and we recompute (internally) the model
+differences to this baseline. We then estimate whether the difference in
+predictive performances is potentially due to chance as described by
 McLatchie and Vehtari (2023). This will flag a warning if it is deemed that
 there is a risk of over-fitting due to the selection process, and users
 are recommended to avoid model selection based on LOO-CV, and

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -66,6 +66,15 @@ better sense of uncertainty than what is obtained using the current
 standard approach of comparing differences of deviances to a Chi-squared
 distribution, a practice derived for Gaussian linear models or
 asymptotically, and which only applies to nested models in any case.
+
+If more than \eqn{11} models are compared, then the worst model by elpd is
+taken as the baseline model, and the risk of difference in predictive
+performance being due to random noise is estimated as described by
+McLatchie and Vehtari (2023). This will flag a warning if it is deemed that
+there is a risk of over-fitting due to the selection process, and users
+are recommended to either avoid model selection based on LOO-CV, and
+instead to favour of model averaging/stacking or projection predictive
+inference.
 }
 \examples{
 # very artificial example, just for demonstration!
@@ -101,6 +110,10 @@ evaluation using leave-one-out cross-validation and WAIC.
 Vehtari, A., Simpson, D., Gelman, A., Yao, Y., and Gabry, J. (2019).
 Pareto smoothed importance sampling.
 \href{https://arxiv.org/abs/1507.02646}{preprint arXiv:1507.02646}
+
+McLatchie, Y., and Vehtari, A. (2023).
+Efficient estimation and correction of selection-induced bias with order statistics.
+\href{https://arxiv.org/abs/2309.03742}{preprint arXiv:2309.03742}
 }
 \seealso{
 \itemize{

--- a/tests/testthat/test_compare.R
+++ b/tests/testthat/test_compare.R
@@ -40,9 +40,10 @@ test_that("loo_compare throws appropriate warnings", {
   attr(w4, "yhash") <- "b"
   expect_warning(loo_compare(w3, w4), "Not all models have the same y variable")
 
+  set.seed(123)
   w_list <- lapply(1:25, function(x) SW(waic(LLarr + rnorm(1, 0, 0.1))))
   expect_warning(loo_compare(w_list),
-                 "Difference in performance potentially due to random noise.")
+                 "Difference in performance potentially due to random noise")
 
   w_list_short <- lapply(1:4, function(x) SW(waic(LLarr + rnorm(1, 0, 0.1))))
   expect_no_warning(loo_compare(w_list_short))

--- a/tests/testthat/test_compare.R
+++ b/tests/testthat/test_compare.R
@@ -43,7 +43,7 @@ test_that("loo_compare throws appropriate warnings", {
   set.seed(123)
   w_list <- lapply(1:25, function(x) SW(waic(LLarr + rnorm(1, 0, 0.1))))
   expect_warning(loo_compare(w_list),
-                 "Difference in performance potentially due to random noise")
+                 "Difference in performance potentially due to chance")
 
   w_list_short <- lapply(1:4, function(x) SW(waic(LLarr + rnorm(1, 0, 0.1))))
   expect_no_warning(loo_compare(w_list_short))

--- a/tests/testthat/test_compare.R
+++ b/tests/testthat/test_compare.R
@@ -39,6 +39,13 @@ test_that("loo_compare throws appropriate warnings", {
   attr(w3, "yhash") <- "a"
   attr(w4, "yhash") <- "b"
   expect_warning(loo_compare(w3, w4), "Not all models have the same y variable")
+
+  w_list <- lapply(1:25, function(x) SW(waic(LLarr + rnorm(1, 0, 0.1))))
+  expect_warning(loo_compare(w_list),
+                 "Difference in performance potentially due to random noise.")
+
+  w_list_short <- lapply(1:4, function(x) SW(waic(LLarr + rnorm(1, 0, 0.1))))
+  expect_no_warning(loo_compare(w_list_short))
 })
 
 


### PR DESCRIPTION
This PR adds a warning when we estimate that the elpd difference of a collection of models is purely due to chance, developed with @avehtari.

If more than 11 models are compared, then the median model by elpd is taken as the baseline model, and the risk of the difference in predictive performance being due to random noise is estimated as described by McLatchie and Vehtari (Section 3.2, [2023](https://arxiv.org/abs/2309.03742)). This will flag a warning if it is deemed that there is a risk of over-fitting due to the selection process, and users are recommended to avoid model selection based on LOO-CV, and instead to favour of model averaging/stacking or projection predictive inference.