### PR TITLE
show NA for n_eff/ESS if k > k_threshold

### DIFF
--- a/R/diagnostics.R
+++ b/R/diagnostics.R
@@ -130,6 +130,7 @@ pareto_k_table <- function(x) {
   S <- dim(x)[1]
   k_threshold <- ps_khat_threshold(S)
   kcut <- k_cut(k, k_threshold)
+  n_eff[k>k_threshold] <- NA
   min_n_eff <- min_n_eff_by_k(n_eff, kcut)
   count <- table(kcut)
   out <- cbind(


### PR DESCRIPTION
Fixes #191

Affects only what is displayed in pareto_k_table. For example, old
```
Computed from 4000 by 262 log-likelihood matrix.

         Estimate   SE
elpd_loo   -859.1 37.7
p_loo        11.4  2.8
looic      1718.2 75.4
------
MCSE of elpd_loo is NA.
MCSE and ESS estimates assume MCMC draws (r_eff in [0.5, 1.2]).

Pareto k diagnostic values:
                         Count Pct.    Min. ESS
(-Inf, 0.7]   (good)     261   99.6%   117     
   (0.7, 1]   (bad)        1    0.4%   71      
   (1, Inf)   (very bad)   0    0.0%   <NA>    
See help('pareto-k-diagnostic') for details.
```
New
```
Computed from 4000 by 262 log-likelihood matrix.

         Estimate   SE
elpd_loo   -859.1 37.7
p_loo        11.4  2.8
looic      1718.2 75.4
------
MCSE of elpd_loo is NA.
MCSE and ESS estimates assume MCMC draws (r_eff in [0.5, 1.2]).

Pareto k diagnostic values:
                         Count Pct.    Min. ESS
(-Inf, 0.7]   (good)     261   99.6%   117     
   (0.7, 1]   (bad)        1    0.4%   <NA>    
   (1, Inf)   (very bad)   0    0.0%   <NA>    
See help('pareto-k-diagnostic') for details.
```