### PR TITLE
make E_loo Pareto-k diagnostic more robust

### DIFF
--- a/R/E_loo.R
+++ b/R/E_loo.R
@@ -51,8 +51,8 @@
 #'   usually the maximum of the Pareto-k's for the left and right tail of \eqn{hr}
 #'   and the right tail of \eqn{r}, where \eqn{r} is the importance ratio and
 #'   \eqn{h=x} for `type="mean"` and \eqn{h=x^2} for `type="var"` and `type="sd"`.
-#'   If \eqn{h} is binary, constant, or not finite, or if type="quantile"`, the
-#'   returned Pareto-k is the Pareto-k for the right tail of \eqn{r}. 
+#'   If \eqn{h} is binary, constant, or not finite, or if `type="quantile"`, the
+#'   returned Pareto-k is the Pareto-k for the right tail of \eqn{r}.
 #'  }
 #' }
 #'

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -193,3 +193,7 @@ release_questions <- function() {
   )
 }
 # nocov end
+
+is_constant <- function(x, tol = .Machine$double.eps) {
+  abs(max(x) - min(x)) < tol
+}

--- a/man/E_loo.Rd
+++ b/man/E_loo.Rd
@@ -71,11 +71,11 @@ calling \code{E_loo()}, the smoothed log-weights are used to estimate
 Pareto-k's, which may produce optimistic estimates.
 
 For \code{type="mean"}, \code{type="var"}, and \code{type="sd"}, the returned Pareto-k is
-the maximum of the Pareto-k's for the left and right tail of \eqn{hr} and
-the right tail of \eqn{r}, where \eqn{r} is the importance ratio and
-\eqn{h=x} for \code{type="mean"} and \eqn{h=x^2} for \code{type="var"} and
-\code{type="sd"}. For \code{type="quantile"}, the returned Pareto-k is the Pareto-k
-for the right tail of \eqn{r}.
+usually the maximum of the Pareto-k's for the left and right tail of \eqn{hr}
+and the right tail of \eqn{r}, where \eqn{r} is the importance ratio and
+\eqn{h=x} for \code{type="mean"} and \eqn{h=x^2} for \code{type="var"} and \code{type="sd"}.
+If \eqn{h} is binary, constant, or not finite, or if \code{type="quantile"}, the
+returned Pareto-k is the Pareto-k for the right tail of \eqn{r}.
 }
 }
 }

--- a/tests/testthat/test_E_loo.R
+++ b/tests/testthat/test_E_loo.R
@@ -115,7 +115,7 @@ test_that("E_loo.matrix equal to reference", {
 test_that("E_loo throws correct errors and warnings", {
   # warnings
   expect_no_warning(E_loo.matrix(x, psis_mat))
-  # now warnings if x is constant, binary, NA, NaN, Inf
+  # no warnings if x is constant, binary, NA, NaN, Inf
   expect_no_warning(E_loo.matrix(x*0, psis_mat))
   expect_no_warning(E_loo.matrix(0+(x>0), psis_mat))
   expect_no_warning(E_loo.matrix(x+NA, psis_mat))   

--- a/tests/testthat/test_E_loo.R
+++ b/tests/testthat/test_E_loo.R
@@ -115,6 +115,12 @@ test_that("E_loo.matrix equal to reference", {
 test_that("E_loo throws correct errors and warnings", {
   # warnings
   expect_no_warning(E_loo.matrix(x, psis_mat))
+  # now warnings if x is constant, binary, NA, NaN, Inf
+  expect_no_warning(E_loo.matrix(x*0, psis_mat))
+  expect_no_warning(E_loo.matrix(0+(x>0), psis_mat))
+  expect_no_warning(E_loo.matrix(x+NA, psis_mat))   
+  expect_no_warning(E_loo.matrix(x*NaN, psis_mat))
+  expect_no_warning(E_loo.matrix(x*Inf, psis_mat))
   expect_no_warning(E_test <- E_loo.default(x[, 1], psis_vec))
   expect_length(E_test$pareto_k, 1)
 
@@ -191,4 +197,3 @@ test_that("weighted variance works", {
   w <- c(rep(0.1, 10), rep(0, 90))
   expect_equal(.wvar(x, w), var(x[w > 0]))
 })
-


### PR DESCRIPTION
Fixes #250 (although the reason was not posterior version)

E_loo was giving warnings and errors in certain cases with binary x. If h(theta) is a step function and h is 0/1 binary, then when computing Pareto-k the one of the tails is likely to be just 0's. In such cases, using the same argument as for type="quantile", we can return the Pareto-k just for r. To make the function to complain less, the same approach is now used for constant, NA, NaN, and infinite x. Added also tests that these don't cause warnings.

