### PR TITLE
fix loo_moment_matching NaN issue

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -57,7 +57,7 @@ validate_ll <- function(x) {
     stop("List not allowed as input.")
   } else if (anyNA(x)) {
     stop("NAs not allowed in input.")
-  } else if (any(x==Inf)) {
+  } else if (any(x == Inf)) {
     stop("All input values must be finite or -Inf.")
   }
   invisible(x)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -57,8 +57,8 @@ validate_ll <- function(x) {
     stop("List not allowed as input.")
   } else if (anyNA(x)) {
     stop("NAs not allowed in input.")
-  } else if (!all(is.finite(x))) {
-    stop("All input values must be finite.")
+  } else if (any(x==Inf)) {
+    stop("All input values must be finite or -Inf.")
   }
   invisible(x)
 }

--- a/R/loo_moment_matching.R
+++ b/R/loo_moment_matching.R
@@ -385,7 +385,6 @@ loo_moment_match_i <- function(i,
     dim(log_liki) <- NULL
   }
 
-
   # pointwise estimates
   elpd_loo_i <- matrixStats::logSumExp(log_liki + lwi)
   lpd <- matrixStats::logSumExp(log_liki) - log(length(log_liki))
@@ -439,17 +438,18 @@ update_quantities_i <- function(x, upars, i, orig_log_prob,
   log_liki_new <- log_lik_i_upars(x, upars = upars, i = i, ...)
   # compute new log importance weights
 
-  is_obj_new <- suppressWarnings(importance_sampling.default(-log_liki_new +
-                                                               log_prob_new -
-                                                               orig_log_prob,
+  # If log_liki_new and log_prob_new both have same element as Inf,
+  # replace the log ratio with -Inf
+  lr <- -log_liki_new + log_prob_new - orig_log_prob
+  lr[is.na(lr)] <- -Inf
+  is_obj_new <- suppressWarnings(importance_sampling.default(lr,
                                                              method = is_method,
                                                              r_eff = r_eff_i,
                                                              cores = 1))
   lwi_new <- as.vector(weights(is_obj_new))
   ki_new <- is_obj_new$diagnostics$pareto_k
 
-  is_obj_f_new <- suppressWarnings(importance_sampling.default(log_prob_new -
-                                                                 orig_log_prob,
+  is_obj_f_new <- suppressWarnings(importance_sampling.default(log_prob_new - orig_log_prob,
                                                                method = is_method,
                                                                r_eff = r_eff_i,
                                                                cores = 1))

--- a/R/split_moment_matching.R
+++ b/R/split_moment_matching.R
@@ -100,7 +100,7 @@ loo_moment_match_split <- function(x, upars, cov, total_shift, total_scaling,
 
   # lwi_half may have NaNs if computation involves -Inf + Inf
   # replace NaN log ratios with -Inf
-  lr<-lwi_half
+  lr <- lwi_half
   lr[is.na(lr)] <- -Inf
   is_obj_half <- suppressWarnings(importance_sampling.default(lr,
                                                               method = is_method,
@@ -110,7 +110,7 @@ loo_moment_match_split <- function(x, upars, cov, total_shift, total_scaling,
 
   # lwi_half may have NaNs if computation involves -Inf + Inf
   # replace NaN log ratios with -Inf
-  lr<-lwi_half + log_liki_half
+  lr <- lwi_half + log_liki_half
   lr[is.na(lr)] <- -Inf
   is_obj_f_half <- suppressWarnings(importance_sampling.default(lr,
                                                                 method = is_method,

--- a/R/split_moment_matching.R
+++ b/R/split_moment_matching.R
@@ -98,14 +98,21 @@ loo_moment_match_split <- function(x, upars, cov, total_shift, total_scaling,
         log1p(exp(log_prob_half_trans[!stable_S] -
                    log_prob_half_trans_inv[!stable_S])))
 
-  is_obj_half <- suppressWarnings(importance_sampling.default(lwi_half,
+  # lwi_half may have NaNs if computation involves -Inf + Inf
+  # replace NaN log ratios with -Inf
+  lr<-lwi_half
+  lr[is.na(lr)] <- -Inf
+  is_obj_half <- suppressWarnings(importance_sampling.default(lr,
                                                               method = is_method,
                                                               r_eff = r_eff_i,
                                                               cores = cores))
   lwi_half <- as.vector(weights(is_obj_half))
 
-  is_obj_f_half <- suppressWarnings(importance_sampling.default(lwi_half +
-                                                                  log_liki_half,
+  # lwi_half may have NaNs if computation involves -Inf + Inf
+  # replace NaN log ratios with -Inf
+  lr<-lwi_half + log_liki_half
+  lr[is.na(lr)] <- -Inf
+  is_obj_f_half <- suppressWarnings(importance_sampling.default(lr,
                                                                 method = is_method,
                                                                 r_eff = r_eff_i,
                                                                 cores = cores))

--- a/tests/testthat/test_loo_moment_matching.R
+++ b/tests/testthat/test_loo_moment_matching.R
@@ -177,6 +177,11 @@ test_that("loo_moment_match.default warnings work", {
 
 test_that("loo_moment_match.default works", {
 
+  # allow -Inf
+  lwi_x <- lwi_1
+  lwi_x[which.min(lwi_1)] <- -Inf
+  expect_no_error(suppressWarnings(importance_sampling.default(lwi_1, method = "psis", r_eff = 1, cores = 1)))
+
   # loo object
   loo_manual <- suppressWarnings(loo(loglik))
 
@@ -286,7 +291,6 @@ test_that("loo_moment_match.default works with multiple cores", {
   expect_equal(loo_moment_match_manual3$pointwise, loo_moment_match_manual4$pointwise, tolerance=5e-4)
 
 })
-
 
 
 test_that("loo_moment_match_split works", {

--- a/tests/testthat/test_psis.R
+++ b/tests/testthat/test_psis.R
@@ -88,8 +88,11 @@ test_that("psis throws correct errors and warnings", {
   expect_error(psis(-LLmat), "NAs not allowed in input")
 
   LLmat[1,1] <- 1
+  LLmat[10, 2] <- -Inf
+  expect_error(psis(-LLmat), "All input values must be finite or -Inf")
+  # log ratio of -Inf is allowed
   LLmat[10, 2] <- Inf
-  expect_error(psis(-LLmat), "All input values must be finite")
+  expect_no_error(psis(-LLmat))
 
   # no lists allowed
   expect_error(expect_warning(psis(as.list(-LLvec))), "List not allowed as input")

--- a/tests/testthat/test_tisis.R
+++ b/tests/testthat/test_tisis.R
@@ -121,8 +121,10 @@ test_that("tis throws correct errors and warnings", {
   expect_error(tis(-LLmat), "NAs not allowed in input")
 
   LLmat[1,1] <- 1
+  LLmat[10, 2] <- -Inf
+  expect_error(tis(-LLmat), "All input values must be finite or -Inf")
   LLmat[10, 2] <- Inf
-  expect_error(tis(-LLmat), "All input values must be finite")
+  expect_no_error(tis(-LLmat))
 
   # no lists allowed
   expect_error(expect_warning(tis(as.list(-LLvec)), "List not allowed as input"))


### PR DESCRIPTION
Fixes #258 

- In `loo_moment_matching` and `split_moment_matching` replace NaN's in log ratios resulting from -Inf + Inf with -Inf before calling `importance_sampling.default()`
- in `validate_ll()` allow -Inf
- update tests