### PR TITLE
fix equations in loo-glossary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -53,5 +53,5 @@ Suggests:
 VignetteBuilder: knitr
 Encoding: UTF-8
 SystemRequirements: pandoc (>= 1.12.3), pandoc-citeproc
-RoxygenNote: 7.3.0
+RoxygenNote: 7.3.1
 Roxygen: list(markdown = TRUE)

--- a/R/loo-glossary.R
+++ b/R/loo-glossary.R
@@ -84,15 +84,15 @@
 #' is usually negligible. Thinning of MCMC draws can be used to improve
 #' the ratio ESS/S.
 #'
-#' * If \eqn{k < min(1 - 1 / log10(S), 0.7)}, where \eqn{S} is the
+#' * If \eqn{k < \min(1 - 1 / \log_{10}(S), 0.7)}, where \eqn{S} is the
 #'   sample size, the PSIS estimate and the corresponding Monte
 #'   Carlo standard error estimate are reliable.
 #'
-#' * If \eqn{1 - 1 / log10(S) <= k < 0.7}, the PSIS estimate and the
+#' * If \eqn{1 - 1 / \log_{10}(S) <= k < 0.7}, the PSIS estimate and the
 #'   corresponding Monte Carlo standard error estimate are not
 #'   reliable, but increasing the (effective) sample size \eqn{S} above
 #'   2200 may help (this will increase the sample size specific
-#'   threshold \eqn{(1 - 1 / log10(2200) > 0.7} and then the bias specific
+#'   threshold \eqn{(1 - 1 / \log_{10}(2200) > 0.7} and then the bias specific
 #'   threshold 0.7 dominates).
 #'
 #' * If \eqn{0.7 <= k < 1}, the PSIS estimate and the corresponding Monte

--- a/man/loo-glossary.Rd
+++ b/man/loo-glossary.Rd
@@ -90,14 +90,14 @@ sample size is less than 2200, but even then if ESS/S > 1/2 the difference
 is usually negligible. Thinning of MCMC draws can be used to improve
 the ratio ESS/S.
 \itemize{
-\item If \eqn{k < min(1 - 1 / log10(S), 0.7)}, where \eqn{S} is the
+\item If \eqn{k < \min(1 - 1 / \log_{10}(S), 0.7)}, where \eqn{S} is the
 sample size, the PSIS estimate and the corresponding Monte
 Carlo standard error estimate are reliable.
-\item If \eqn{1 - 1 / log10(S) <= k < 0.7}, the PSIS estimate and the
+\item If \eqn{1 - 1 / \log_{10}(S) <= k < 0.7}, the PSIS estimate and the
 corresponding Monte Carlo standard error estimate are not
 reliable, but increasing the (effective) sample size \eqn{S} above
 2200 may help (this will increase the sample size specific
-threshold \eqn{(1 - 1 / log10(2200) > 0.7} and then the bias specific
+threshold \eqn{(1 - 1 / \log_{10}(2200) > 0.7} and then the bias specific
 threshold 0.7 dominates).
 \item If \eqn{0.7 <= k < 1}, the PSIS estimate and the corresponding Monte
 Carlo standard error have large bias and are not reliable. Increasing


### PR DESCRIPTION
At some point I had added \eqn{}, but forgot to change R  code to LaTeX equations, This fixes that