### PR TITLE
Fix url in vignette

### DIFF
--- a/vignettes/loo2-example.Rmd
+++ b/vignettes/loo2-example.Rmd
@@ -62,7 +62,7 @@ models.
 ### Roaches data
 
 The example data we'll use comes from Chapter 8.3 of [Gelman and Hill
-(2007)](http://www.stat.columbia.edu/~gelman/arm/). We want to make inferences
+(2007)](https://sites.stat.columbia.edu/gelman/arm/). We want to make inferences
 about the efficacy of a certain pest management system at reducing the number of
 roaches in urban apartments. Here is how Gelman and Hill describe the experiment
 and data (pg. 161):


### PR DESCRIPTION
Columbia is now redirecting the URL for the original Gelman and Hill book to 

https://sites.stat.columbia.edu/gelman/arm/ 