### PR TITLE
Fixed NAs in psis_r_eff 

### DIFF
--- a/R/psis.R
+++ b/R/psis.R
@@ -362,7 +362,8 @@ prepare_psis_r_eff <- function(r_eff, len) {
   } else if (length(r_eff) != len) {
     stop("'r_eff' must have one value or one value per observation.", call. = FALSE)
   } else if (anyNA(r_eff)) {
-    stop("Can't mix NA and not NA values in 'r_eff'.", call. = FALSE)
+    message("If `r_eff` has length `len` but has `NA`s then `NA`s are replaced with 1's.")
+    r_eff[is.na(r_eff)] <- 1
   }
   r_eff
 }

--- a/tests/testthat/_snaps/psis.md
+++ b/tests/testthat/_snaps/psis.md
@@ -4783,6 +4783,19 @@
 # psis throws correct errors and warnings
 
     Code
+      psis(-LLarr, r_eff = r_eff_arr)
+    Message
+      If `r_eff` has length `len` but has `NA`s then `NA`s are replaced with 1's.
+    Output
+      Computed from 1000 by 32 log-weights matrix.
+      MCSE and ESS estimates assume MCMC draws (r_eff in [0.6, 1.0]).
+      
+      All Pareto k estimates are good (k < 0.67).
+      See help('pareto-k-diagnostic') for details.
+
+---
+
+    Code
       psis(-LLarr[1:5, , ])
     Condition
       Warning:

--- a/tests/testthat/_snaps/tisis.md
+++ b/tests/testthat/_snaps/tisis.md
@@ -1,0 +1,13 @@
+# tis throws correct errors and warnings
+
+    Code
+      psis(-LLarr, r_eff = r_eff_arr)
+    Message
+      If `r_eff` has length `len` but has `NA`s then `NA`s are replaced with 1's.
+    Output
+      Computed from 1000 by 32 log-weights matrix.
+      MCSE and ESS estimates assume MCMC draws (r_eff in [0.6, 1.0]).
+      
+      All Pareto k estimates are good (k < 0.67).
+      See help('pareto-k-diagnostic') for details.
+

--- a/tests/testthat/test_psis.R
+++ b/tests/testthat/test_psis.R
@@ -70,9 +70,9 @@ test_that("psis throws correct errors and warnings", {
   # r_eff non-scalar wrong length is error
   expect_error(psis(-LLarr, r_eff = r_eff_arr[-1]), "one value per observation")
 
-  # r_eff has some NA values causes error
+  # r_eff has some NA values which are replaced with 1
   r_eff_arr[2] <- NA
-  expect_error(psis(-LLarr, r_eff = r_eff_arr), "mix NA and not NA values")
+  expect_snapshot(psis(-LLarr, r_eff = r_eff_arr))
 
   # tail length warnings
   expect_snapshot(psis(-LLarr[1:5, , ]))

--- a/tests/testthat/test_tisis.R
+++ b/tests/testthat/test_tisis.R
@@ -107,9 +107,9 @@ test_that("tis throws correct errors and warnings", {
   # r_eff wrong length is error
   expect_error(tis(-LLarr, r_eff = r_eff_arr[-1]), "one value per observation")
 
-  # r_eff has some NA values causes error
+  # r_eff has some NA values which are replaced with 1
   r_eff_arr[2] <- NA
-  expect_error(tis(-LLarr, r_eff = r_eff_arr), "mix NA and not NA values")
+  expect_snapshot(psis(-LLarr, r_eff = r_eff_arr))
 
   # no NAs or non-finite values allowed
   LLmat[1, 1] <- NA


### PR DESCRIPTION
Fixed NA issues in psis_r_eff by replacing NA values with 1s.