### PR TITLE
Fix garbled error message for invalid importance sampling method

### DIFF
--- a/R/importance_sampling.R
+++ b/R/importance_sampling.R
@@ -114,7 +114,7 @@ assert_importance_sampling_method_is_implemented <- function(x){
     stop("Importance sampling method '",
          x,
          "' is not implemented. Implemented methods: '",
-         paste0(implemented_is_methods, collapse = "', '"),
+         paste0(implemented_is_methods(), collapse = "', '"),
          "'")
   }
 }

--- a/tests/testthat/test_tisis.R
+++ b/tests/testthat/test_tisis.R
@@ -224,3 +224,16 @@ test_that("tis_loo and sis_loo are returned", {
   expect_output(print(loo_tis), regexp = "tis_loo")
   expect_output(print(loo_sis), regexp = "sis_loo")
 })
+
+test_that("invalid IS method gives informative error listing valid methods", {
+  LLmat <- example_loglik_matrix()
+  expect_error(
+    loo(LLmat, r_eff = NA, is_method = "bad_method"),
+    "'arg' should be one of"
+  )
+  expect_error(
+    importance_sampling(-LLmat, method = "not_a_method", r_eff = NA),
+    "Implemented methods: 'psis', 'tis', 'sis'",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
Fixes #331

`assert_importance_sampling_method_is_implemented()` was referencing the function object `implemented_is_methods` rather than calling it with `()`. This meant the error message for an invalid IS method would print the function body instead of the actual method names.

### Before
```
Importance sampling method 'foo' is not implemented. Implemented methods: 'function () 
c("psis", "tis", "sis")'
```

### After
```
Importance sampling method 'foo' is not implemented. Implemented methods: 'psis', 'tis', 'sis'
```

Added a test to verify the error message lists the valid methods.