### PR TITLE
Fix `.balanced_accuracy()` returning NaN for single-class data

### DIFF
--- a/R/loo_predictive_metric.R
+++ b/R/loo_predictive_metric.R
@@ -197,6 +197,11 @@ loo_predictive_metric.matrix <-
   yhat <- as.integer(yhat > 0.5)
   mask <- y == 0
 
+  if (all(mask) || !any(mask)) {
+    stop("Balanced accuracy requires both classes (0 and 1) to be present in 'y'.",
+         call. = FALSE)
+  }
+
   tn <- mean(yhat[mask] == y[mask]) # True negatives
   tp <- mean(yhat[!mask] == y[!mask]) # True positives
 

--- a/tests/testthat/test_loo_predictive_metric.R
+++ b/tests/testthat/test_loo_predictive_metric.R
@@ -170,4 +170,14 @@ test_that('Balanced accuracy computation is correct', {
     'all(yhat <= 1 & yhat >= 0) is not TRUE',
     fixed = TRUE
   )
+  expect_error(
+    .balanced_accuracy(c(1, 1, 1, 1), c(0.8, 0.6, 0.7, 0.9)),
+    'Balanced accuracy requires both classes',
+    fixed = TRUE
+  )
+  expect_error(
+    .balanced_accuracy(c(0, 0, 0, 0), c(0.1, 0.2, 0.3, 0.4)),
+    'Balanced accuracy requires both classes',
+    fixed = TRUE
+  )
 })


### PR DESCRIPTION
Hey! I noticed that `.balanced_accuracy()` in `loo_predictive_metric.R` silently returns `NaN` when all observations belong to a single class (e.g., all 1s or all 0s). This happens because `mean()` gets called on an empty subset — `yhat[mask]` is length 0 when there are no negatives (or no positives), and `mean(integer(0))` gives `NaN`.

Quick repro:
```r
loo:::.balanced_accuracy(c(1, 1, 1, 1), c(0.8, 0.6, 0.7, 0.9))
# $estimate: NaN
# $se: NaN
```

Since balanced accuracy is inherently undefined with only one class present, this PR adds a guard clause that throws a clear error message instead of silently returning garbage values. Also added tests for both single-class cases (all 0s and all 1s).

All existing tests still pass.