### PR TITLE
Bump R version to 3.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ License: GPL (>=3)
 URL: https://mc-stan.org/loo/, https://discourse.mc-stan.org
 BugReports: https://github.com/stan-dev/loo/issues
 Depends:
-    R (>= 3.1.2)
+    R (>= 3.5)
 Imports:
     checkmate,
     matrixStats (>= 0.52),


### PR DESCRIPTION
In R cmd check we now get this: 

```
  NB: this package now depends on R (>= 3.5.0)
  WARNING: Added dependency on R >= 3.5.0 because serialized objects in
  serialize/load version 3 cannot be read in older versions of R.
  File(s) containing such objects:
    ‘loo/tests/testthat/data-for-tests/kfold-calibrated.Rds’
    ‘loo/tests/testthat/data-for-tests/kfold-miscalibrated.Rds’
```

We could replace these files using `saveRDS(..., version = 2)`, which should get rid of this warning, but I think it's also fine to just require R 3.5.0 since that's still a very old version of R. In fact there may even be other things in the package at this point that require later versions of R that we're not aware of. 