### PR TITLE
feat: re-add simplify= to print.compare.loo (#366)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 * `loo_compare()` output now includes additional columns: `p_worse`,
   `diag_diff`, and `diag_elpd`, providing richer diagnostics for model
   comparison by @florence-bockting in #300
+* `print.compare.loo()` regains a `simplify = FALSE` mode for showing the full
+  comparison table, including the available estimate and standard-error columns
 
 # loo 2.9.0
 

--- a/R/loo_compare.R
+++ b/R/loo_compare.R
@@ -92,6 +92,9 @@
 #' comp <- loo_compare(loo1, loo2, loo3)
 #' print(comp, digits = 2)
 #'
+#' # print full table with pointwise ELPD and LOOIC
+#' print(comp, simplify = FALSE)
+#'
 #' # can use a list of objects with custom names
 #' # the names will be used in the output
 #' loo_compare(list("apple" = loo1, "banana" = loo2, "cherry" = loo3))
@@ -170,7 +173,11 @@ loo_compare.default <- function(x, ...) {
 #' @param p_worse For the print method only, should we include the normal
 #'   approximation based probability of each model having worse performance than
 #'   the best model? The default is `TRUE`.
-print.compare.loo <- function(x, ..., digits = 1, p_worse = TRUE) {
+#' @param simplify For the print method only, should the output be simplified
+#'   to only include the model names and ELPD differences? The default is
+#'   `TRUE`. If `FALSE`, the full comparison table is printed including
+#'   pointwise ELPD, LOOIC/WAIC, and their standard errors for each model.
+print.compare.loo <- function(x, ..., digits = 1, p_worse = TRUE, simplify = TRUE) {
   if (inherits(x, "old_compare.loo")) {
     return(unclass(x))
   }
@@ -192,6 +199,16 @@ print.compare.loo <- function(x, ..., digits = 1, p_worse = TRUE) {
       diag_diff = x[, "diag_diff"],
       diag_elpd = x[, "diag_elpd"]
     )
+  }
+  if (!simplify) {
+    est_cols <- c("elpd_loo", "se_elpd_loo", "p_loo", "se_p_loo",
+                  "looic", "se_looic",
+                  "elpd_waic", "se_elpd_waic", "p_waic", "se_p_waic",
+                  "waic", "se_waic")
+    avail <- intersect(est_cols, colnames(x))
+    if (length(avail)) {
+      x2 <- cbind(x2, .fr(x[, avail], digits))
+    }
   }
   print(x2, quote = FALSE, row.names = FALSE)
 

--- a/man/loo-package.Rd
+++ b/man/loo-package.Rd
@@ -124,9 +124,9 @@ Authors:
 \itemize{
   \item Jonah Gabry \email{jgabry@gmail.com}
   \item Aki Vehtari \email{Aki.Vehtari@aalto.fi}
-  \item Måns Magnusson
+  \item M<U+00E5>ns Magnusson
   \item Yuling Yao
-  \item Paul-Christian Bürkner
+  \item Paul-Christian B<U+00FC>rkner
   \item Topi Paananen
   \item Andrew Gelman
 }

--- a/man/loo-package.Rd
+++ b/man/loo-package.Rd
@@ -124,9 +124,9 @@ Authors:
 \itemize{
   \item Jonah Gabry \email{jgabry@gmail.com}
   \item Aki Vehtari \email{Aki.Vehtari@aalto.fi}
-  \item M<U+00E5>ns Magnusson
+  \item Måns Magnusson
   \item Yuling Yao
-  \item Paul-Christian B<U+00FC>rkner
+  \item Paul-Christian Bürkner
   \item Topi Paananen
   \item Andrew Gelman
 }

--- a/man/loo_compare.Rd
+++ b/man/loo_compare.Rd
@@ -12,7 +12,7 @@ loo_compare(x, ...)
 
 \method{loo_compare}{default}(x, ...)
 
-\method{print}{compare.loo}(x, ..., digits = 1, p_worse = TRUE)
+\method{print}{compare.loo}(x, ..., digits = 1, p_worse = TRUE, simplify = TRUE)
 
 \method{print}{compare.loo_ss}(x, ..., digits = 1)
 }
@@ -30,6 +30,11 @@ printing.}
 \item{p_worse}{For the print method only, should we include the normal
 approximation based probability of each model having worse performance than
 the best model? The default is \code{TRUE}.}
+
+\item{simplify}{For the print method only, should the output be simplified
+to only include the model names and ELPD differences? The default is
+\code{TRUE}. If \code{FALSE}, the full comparison table is printed including
+pointwise ELPD, LOOIC/WAIC, and their standard errors for each model.}
 }
 \value{
 A data frame with class \code{"compare.loo"} that has its own
@@ -118,6 +123,9 @@ loo3 <- loo(LL + 2) # should be best model when compared
 
 comp <- loo_compare(loo1, loo2, loo3)
 print(comp, digits = 2)
+
+# print full table with pointwise ELPD and LOOIC
+print(comp, simplify = FALSE)
 
 # can use a list of objects with custom names
 # the names will be used in the output

--- a/tests/testthat/test_compare.R
+++ b/tests/testthat/test_compare.R
@@ -109,6 +109,13 @@ test_that("loo_compare returns expected results (2 models)", {
   expect_snapshot_value(comp2, style = "serialize")
   expect_snapshot(print(comp2))
   expect_snapshot(print(comp2, p_worse = FALSE))
+  out_full <- paste(
+    capture.output(suppressMessages(print(comp2, simplify = FALSE))),
+    collapse = "\n"
+  )
+  expect_match(out_full, "elpd_waic\\s+se_elpd_waic")
+  expect_match(out_full, "p_waic\\s+se_p_waic\\s+waic\\s+se_waic")
+  expect_message(print(comp2, simplify = FALSE), "Diagnostic flags present.", fixed = TRUE)
 
   # specifying objects via ... and via arg x gives equal results
   expect_equal(comp2, loo_compare(x = list(w1, w2)))


### PR DESCRIPTION
## Summary

This follow-up keeps the `simplify` restoration on `print.compare.loo()` and adds the missing focused coverage for the full-output path.

## Thanks to maintainers

Thanks for the review and for pointing out the missing tests, scope cleanup, and AI disclosure requirement.

## Issue or motivation

This PR follows up on #366 by restoring `simplify = FALSE` for `print.compare.loo()`, while keeping the default simplified output unchanged.

## Root cause

The earlier branch restored the argument and print-path behavior, but it did not include focused test coverage for the full-output branch and it also carried an unrelated generated-file change.

## Change

- restore `simplify` in `print.compare.loo()` with default `TRUE`
- document the restored full-output mode
- add focused tests for `print(comp2, simplify = FALSE)` and the full comparison columns
- keep the PR diff scoped by excluding the unrelated `loo-package.Rd` drift

## Tests

- `Rscript -e 'devtools::test(filter = "compare", stop_on_failure = TRUE)'`
- `R CMD build --no-build-vignettes .`
- `_R_CHECK_FORCE_SUGGESTS_=false R CMD check --no-manual --ignore-vignettes --no-build-vignettes loo_2.9.0.9000.tar.gz`

I used AI assistance to help check for issues, refine the code, and run tests.

## Scope

This follow-up does not change the default printed output, does not alter model-comparison calculations, and does not expand the feature beyond the existing `print.compare.loo()` path discussed here.
