### PR TITLE
Update touchstone GHA to use touchstone@main

### DIFF
--- a/.github/workflows/touchstone-receive.yaml
+++ b/.github/workflows/touchstone-receive.yaml
@@ -41,3 +41,4 @@ jobs:
       - uses: lorenzwalthert/touchstone/actions/receive@main
         with:
           r-version: ${{ matrix.config.r }}
+          touchstone_ref: '@main'


### PR DESCRIPTION
Change touchstone GHA to download latest version of touchstone package instead of [v1](default: '@v1'). This should fix [this empty comment](https://github.com/stan-dev/loo/pull/369#issuecomment-4640840340) which is due to the branch having a slash.