### PR TITLE
Mention new loo_compare columns in vignette

### DIFF
--- a/vignettes/loo2-example.Rmd
+++ b/vignettes/loo2-example.Rmd
@@ -272,10 +272,14 @@ loo_compare(loo1, loo2)
 
 The difference in ELPD is much larger than several times the estimated standard
 error of the difference again indicating that the negative-binomial model is
-xpected to have better predictive performance than the Poisson model. However,
+expected to have better predictive performance than the Poisson model. However,
 according to the LOO-PIT checks there is still some misspecification, and a
 reasonable guess is that a hurdle or zero-inflated model would be an improvement
 (we leave that for another case study).
+
+The `p_worse`, `diag_diff`, and `diag_elpd` columns are new as of version 2.10. 
+For details on interpreting them see ?`loo-glossary` and the case study 
+[Uncertainty in Bayesian LOO-CV Model Comparison](https://users.aalto.fi/~ave/casestudies/LOO_uncertainty/loo_uncertainty.html).
 
 
 <br>


### PR DESCRIPTION
Briefly mention new `loo_compare` output in the main vignette. For now I just point to the glossary and Aki and Florence's case study. 