### PR TITLE
Restore original loo k behaviour

### DIFF
--- a/R/psis.R
+++ b/R/psis.R
@@ -257,6 +257,9 @@ psis_smooth_tail <- function(x, cutoff) {
   fit <- posterior::gpdfit(exp(x) - exp_cutoff, sort_x = FALSE)
   k <- fit$k
   sigma <- fit$sigma
+  if (is.na(k)) {
+    k <- Inf
+  }
   if (is.finite(k)) {
     p <- (seq_len(len) - 0.5) / len
     qq <- posterior::qgeneralized_pareto(p, 0, sigma, k) + exp_cutoff

--- a/tests/testthat/test_psis.R
+++ b/tests/testthat/test_psis.R
@@ -153,11 +153,9 @@ test_that("do_psis_i throws warning if all tail values the same", {
 })
 
 test_that("psis_smooth_tail returns original tail values if k is infinite", {
-  # skip on M1 Mac until we figure out why this test fails only on M1 Mac
-  skip_if(Sys.info()[["sysname"]] == "Darwin" && R.version$arch == "aarch64")
-
-  xx <- c(1, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4)
-  val <- suppressWarnings(psis_smooth_tail(xx, 3))
+  xx <- log(c(2, 2, 2, 2, 3, 4, 5, 6))
+  val <- suppressWarnings(psis_smooth_tail(xx, 0))
   expect_equal(val$tail, xx)
   expect_equal(val$k, Inf)
 })
+


### PR DESCRIPTION
This PR was made with assistance from Codex.

#354 swapped psis pareto calculations to use posteriors functions, but `loo` before 2.10 used to never return `k = NA` (see [here in 2.9](https://github.com/stan-dev/loo/blob/v2.9.0/R/gpdfit.R#L52)), while `posterior` does (see [here](https://github.com/stan-dev/posterior/blob/master/R/gpd.R#L178)). This PR rectifies that inadvertent change in API.